### PR TITLE
Fix schema validation: Use 'schemas' table instead of 'floating_schemas'

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -386,7 +386,7 @@ class ProjectController extends Controller
         }
 
         $validated = $request->validate([
-            'schema_id' => 'required|exists:floating_schemas,id',
+            'schema_id' => 'required|exists:schemas,id',
             'association_type' => 'required|in:linked,cloned,imported',
             'alias' => 'nullable|string|max:255',
         ]);


### PR DESCRIPTION
Fix schema validation: Use 'schemas' table instead of 'floating_schemas'