### PR TITLE
Fix API authentication: Return 401 instead of redirecting to login

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -8,6 +8,11 @@ class Authenticate extends Middleware
 {
     protected function redirectTo($request): ?string
     {
+        // Never redirect API requests - always return 401
+        if ($request->is('api/*')) {
+            return null;
+        }
+
         if (! $request->expectsJson()) {
             return route('login');
         }


### PR DESCRIPTION
The Authenticate middleware was redirecting API requests to the login page instead of returning proper 401 Unauthorized responses. This caused the frontend to receive 404 errors instead of proper authentication failures.

- API routes (api/*) now always return 401 when unauthenticated
- Web routes continue to redirect to login as expected
- Fixes schema assignment and other API authentication issues

🤖 Generated with [Claude Code](https://claude.ai/code)