### PR TITLE
Fix project ownership detection across environments

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -74,7 +74,7 @@ class ProjectController extends Controller
                 ->map(function ($project) use ($user) {
                     $counts = $project->getCounts();
                     return array_merge($project->toArray(), $counts, [
-                        'is_owner' => $project->owner_id === $user->id,
+                        'is_owner' => (string)$project->owner_id === (string)$user->id,
                     ]);
                 });
 


### PR DESCRIPTION
Fixed is_owner field returning false when user actually owns project. The issue was strict comparison (===) between owner_id and user_id without proper type casting for cross-platform compatibility.

Changes:
- Cast both owner_id and user_id to string before comparison
- Fixes teams assignment and applications permissions
- Resolves "is_owner: false" issue in API responses

🤖 Generated with [Claude Code](https://claude.ai/code)