### PR TITLE
Fix getAssignedTeams permission check consistency

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -289,15 +289,8 @@ class ProjectController extends Controller
      */
     public function getAssignedTeams(Project $project): JsonResponse
     {
-        $user = Auth::user();
-        
-        // Check if user has access to this project (owner or team member)
-        $hasAccess = $project->owner_id === $user->id || 
-                    $project->teams()->whereHas('members', function($query) use ($user) {
-                        $query->where('user_id', $user->id);
-                    })->exists();
-        
-        if (!$hasAccess) {
+        // Check if user has access to this project
+        if (!$this->userHasProjectAccess($project)) {
             return response()->json(['message' => 'Unauthorized'], 403);
         }
 


### PR DESCRIPTION
The getAssignedTeams method was using strict comparison (===) for owner_id check, causing 403 errors even when user is the actual owner.

Changes:
- Replace manual permission check with userHasProjectAccess()
- Ensures consistent cross-platform string casting behavior
- Fixes "teams/assigned 403" while "teams/available 200" worked

Now both team endpoints use the same permission logic.

🤖 Generated with [Claude Code](https://claude.ai/code)