### PR TITLE
Fix User.isTeamOwner() cross-platform compatibility

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -84,7 +84,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function isTeamOwner(Team $team): bool
     {
-        return $team->project_owner_id === $this->id;
+        return (string)$team->project_owner_id === (string)$this->id;
     }
 
     public function getTeamRole(Team $team): ?string


### PR DESCRIPTION
Added string casting to prevent type comparison issues between Windows (integer IDs) and Linux (string IDs) environments.

Though not currently used, this prevents future bugs if the method gets called later.

🤖 Generated with [Claude Code](https://claude.ai/code)