### PR TITLE
Fix removeTeam cross-platform permission check

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -353,7 +353,7 @@ class ProjectController extends Controller
         }
 
         // Check if team belongs to user
-        if ($team->project_owner_id !== Auth::id()) {
+        if ((string)$team->project_owner_id !== (string)Auth::id()) {
             return response()->json(['message' => 'Team does not belong to you'], 403);
         }
 


### PR DESCRIPTION
Fixed team ownership validation using string casting to prevent type comparison issues between Windows and Linux environments.

Resolves 403 error when removing teams from projects.

🤖 Generated with [Claude Code](https://claude.ai/code)